### PR TITLE
Fix binary ops and simplify string ctor

### DIFF
--- a/fixedpoint/fixed.d
+++ b/fixedpoint/fixed.d
@@ -56,16 +56,14 @@ struct Fixed(int scaling)
         if (!s.empty)
         {
             auto spl = s.splitter(".");
-            value = spl.front.chain('0'.repeat(scaling)).to!long;
+            auto frontItem = spl.front;
             spl.popFront;
-            if (!spl.empty && spl.front.length > 0)
-            {
-                const auto decimal = spl.front;
-                if (decimal.length > scaling)
-                    value += value.sgn * decimal[0..scaling].to!long;
-                else
-                    value += value.sgn * decimal.chain('0'.repeat(scaling - decimal.length)).to!long;
-            }
+            typeof(frontItem) decimal;
+            if (!spl.empty)
+                decimal = spl.front;
+            if (decimal.length > scaling)
+                decimal = decimal[0 .. scaling]; // truncate
+            value = chain(frontItem, decimal, '0'.repeat(scaling - decimal.length)).to!long;
         }
     }
     ///


### PR DESCRIPTION
Here are some changes I needed for my code base. I also simplified the ctor to be one `to` call.

I didn't do mod operator, because I'm not familiar with what should be expected for a decimal.

I also didn't do multiplication and division between fixed points because technically, you should multiply the factors together. e.g. `0.01 * 0.01 == 0.0001`, and division should divide the factors (I think, division is tricky). So you may want to have e.g. `typeof(Fixed!2.init * Fixed!2.init) == Fixed!4`.

In any case, I don't need those features for my purposes. I'm now using your library in my code. If I find anything else, I'll post an issue or PR.